### PR TITLE
Restructuring and numerous default definitions

### DIFF
--- a/default.sh
+++ b/default.sh
@@ -34,19 +34,19 @@ fi
 #-------------------------------------------------------------
 # The 'ls/ll' family (use a recent GNU ls).
 #-------------------------------------------------------------
-alias la='ls -A'           #  Show hidden files
+alias la='ls -A'           #  Show (a)ll hidden files
 alias l='ls -CF'           #  Column output + indicator
-alias lx='ls -lXB'         #  Sort by extension.
-alias lk='ls -lSr'         #  Sort by size, biggest last.
-alias lt='ls -ltr'         #  Sort by date, most recent last.
-alias lc='ls -ltcr'        #  Sort by/show change time,most recent last.
-alias lu='ls -ltur'        #  Sort by/show access time,most recent last.
+alias lx='ls -lXB'         #  Sort by e(x)tension.
+alias lk='ls -lSr'         #  Sort by size (biggest last)
+alias lt='ls -ltr'         #  Sort by (t)ime (date, most recent last).
+alias lc='ls -ltcr'        #  Sort by (c)hange (most recent last)
+alias lu='ls -ltur'        #  Sort by (u)sage/access (most recent last).
 # ll: directories first, with alphanumeric sorting:
 alias ll="ls -lv --group-directories-first"
-alias lm='ll |more'        #  Pipe through 'more'
-alias lr='ll -R'           #  Recursive ls.
-alias lla='ll -A'          #  Show hidden files.
-alias tree='tree -Csuh'    #  Nice alternative to 'recursive ls' ...
+alias lm='ll |more'        #  Pipe through '(m)ore'
+alias lr='ll -R'           #  (R)ecursive ll.
+alias lla='ll -A'          #  Show (a)ll hidden files.
+alias tree='tree -Csuh'    #  Alternative to 'recursive ls' ...
 
 #-------------------------------------------------------------
 # 'cd'
@@ -65,10 +65,10 @@ alias .........='cd ../../../../../../../..'
 # Grep
 #-------------------------------------------------------------
 # The following 3 are defined by default
-# alias rgrep='grep -r'    # recursive grep
-# alias fgrep)='grep -F'   # Fixed string list
-# egrep='grep -E'          # Extended Regex
-alias igrep='grep -i'      # case insensitive
+# alias rgrep='grep -r'    # (r)ecursive grep
+# alias fgrep='grep -F'    # (F)ixed string list
+# alias egrep='grep -E'    # (E)xtended Regex
+alias igrep='grep -i'      # case (i)nsensitive
 export GREP_OPTIONS='--color=auto'
 
 #-------------------------------------------------------------

--- a/default.sh
+++ b/default.sh
@@ -11,50 +11,118 @@ if [ -d /cvmfs/sft.cern.ch ] && [ -d /cvmfs/cms.cern.ch ]; then
 else
     [ "$TERM" != "dumb" ] && [ ! -z $ISLOGIN ] && echo "cvmfs not available!"
 fi
+
 export PATH=$BASHRCDIR/scripts:$PATH
 
-# TERMINAL COLORS
+#-------------------------------------------------------------
+# Terminal colors
+#-------------------------------------------------------------
 [ -f "$BASHRCDIR/dir_colors" ] && eval `dircolors $BASHRCDIR/dir_colors` || eval `dircolors -b`
 
 if [ -x /usr/bin/dircolors ]; then
     test -r ~/.dircolors && eval "$(dircolors -b ~/.dircolors)" || eval "$(dircolors -b)"
-    alias ls='ls --color=auto'
+    alias ls='ls -h --color=auto'
     alias dir='dir --color=auto'
     alias vdir='vdir --color=auto'
     alias grep='grep --color=auto'
     alias fgrep='fgrep --color=auto'
     alias egrep='egrep --color=auto'
+else
+    alias ls='ls -h'
 fi
 
-# some more ls aliases
-alias ll='ls -l'
-alias llt='ll -t'
-alias la='ls -A'
-alias l='ls -CF'
+#-------------------------------------------------------------
+# The 'ls/ll' family (use a recent GNU ls).
+#-------------------------------------------------------------
+alias la='ls -A'           #  Show hidden files
+alias l='ls -CF'           #  Column output + indicator
+alias lx='ls -lXB'         #  Sort by extension.
+alias lk='ls -lSr'         #  Sort by size, biggest last.
+alias lt='ls -ltr'         #  Sort by date, most recent last.
+alias lc='ls -ltcr'        #  Sort by/show change time,most recent last.
+alias lu='ls -ltur'        #  Sort by/show access time,most recent last.
+# ll: directories first, with alphanumeric sorting:
+alias ll="ls -lv --group-directories-first"
+alias lm='ll |more'        #  Pipe through 'more'
+alias lr='ll -R'           #  Recursive ls.
+alias lla='ll -A'          #  Show hidden files.
+alias tree='tree -Csuh'    #  Nice alternative to 'recursive ls' ...
+
+#-------------------------------------------------------------
+# 'cd'
+# Each point after .. adds an additional level.
+#-------------------------------------------------------------
+alias ..='cd ..'
+alias ...='cd ../..'
+alias ....='cd ../../..'
+alias .....='cd ../../../..'
+alias ......='cd ../../../../..'
+alias .......='cd ../../../../../..'
+alias ........='cd ../../../../../../..'
+alias .........='cd ../../../../../../../..'
+
+#-------------------------------------------------------------
+# Grep
+#-------------------------------------------------------------
+# The following 3 are defined by default
+# alias rgrep='grep -r'    # recursive grep
+# alias fgrep)='grep -F'   # Fixed string list
+# egrep='grep -E'          # Extended Regex
+alias igrep='grep -i'      # case insensitive
+export GREP_OPTIONS='--color=auto'
+
+#-------------------------------------------------------------
+# Convert unix-time to human readable format
+#-------------------------------------------------------------
+function utime(){
+    if [ -n $1 ]; then
+        printf '%(%F %T)T\n' "$1"
+    fi
+}
+
+#-------------------------------------------------------------
 # history
+#-------------------------------------------------------------
 export HISTFILE=$HOME/.bash_history
 export HISTFILESIZE=1000000
 export HISTSIZE=100000
 export HISTCONTROL=ignoreboth
 shopt -s histappend
 shopt -s checkwinsize
+alias h='history'
 
-# This function is needed to display the current git branch in the bash prompt
-function parse_git_branch_and_add_brackets {
-  git branch --no-color 2> /dev/null | sed -e '/^[^*]/d' -e 's/* \(.*\)/\ \[\1\]/'
-}
+#-------------------------------------------------------------
+# file system usage
+#-------------------------------------------------------------
+alias du='du -kh'    # Makes a more readable output.
+alias df='df -kTh'
+
+#-------------------------------------------------------------
+# Hostname colors
+#-------------------------------------------------------------
 if [ $HOSTNAME = "ekpcms6" ]; then
     export PS1HOSTCOLOR="1;33"
+elif [[ $HOSTNAME = "ekpcondorcentral" ]]; then
+    export PS1HOSTCOLOR="1;31"
 elif [ $HOSTNAME = "nafhh-cms01" ]; then
     export PS1HOSTCOLOR="1;36"
-elif [[ $HOSTNAME == *cms03* ]]; then
-    export PS1HOSTCOLOR="1;35"
 else
     export PS1HOSTCOLOR="0;32"
 fi
+
+#-------------------------------------------------------------
+# Git
+#-------------------------------------------------------------
+function parse_git_branch_and_add_brackets {
+  git branch --no-color 2> /dev/null | sed -e '/^[^*]/d' -e 's/* \(.*\)/\ \[\1\]/'
+}
+[ -f $BASHRCDIR/git-completion.bash ] && source $BASHRCDIR/git-completion.bash
+
 export PS1='\[\e[${PS1HOSTCOLOR}m\][$(date +%H:%M)] \h:\[\e[m\]\[\e[1;34m\]\w\[\e[m\]$(parse_git_branch_and_add_brackets) \[\e[1;32m\]\$\[\e[m\] \[\e[1;37m\]\[\033[00m\]'
 
-# Set terminal title depending on host
+#-------------------------------------------------------------
+# Terminal titles (depending on host)
+#-------------------------------------------------------------
 if [[ $HOSTNAME == *ekpcms5* ]]; then
         STR="[5]"
 elif [[ $HOSTNAME == *ekpcms6* ]]; then
@@ -70,20 +138,20 @@ else
 fi
 export PROMPT_COMMAND='echo -ne "\033]0;${STR}${PWD/$HOME/~}\007"'
 
+#-------------------------------------------------------------
+# mensa plan and list of PDG-IDs
+#-------------------------------------------------------------
+alias mensa='curl http://mensa.akk.uni-karlsruhe.de/ -d DATUM=heute -d uni=1 -d schnell=1 -s | w3m -dump -T text/html| head -n 25 | tail -n 18'
+alias pdgid='curl https://twiki.cern.ch/twiki/bin/view/Main/PdgId -Bs | w3m -dump -s -no-graph -T text/html | head -n 7 | tail -n 45| less'
 
-[ -f $BASHRCDIR/git-completion.bash ] && source $BASHRCDIR/git-completion.bash
-
-# display mensa plan and list of PDG-IDs
-alias mensa='curl http://mensa.akk.uni-karlsruhe.de/?DATUM=heute -s | w3m -dump -T text/html| head -n 56 | tail -n 49 | less -p 'Linie''
-alias pdgid='curl http://www.physics.ox.ac.uk/CDF/Mphys/old/notes/pythia_codeListing.html -s | w3m -dump -T text/html | head -n 60 | tail -n 55| less'
-
+#-------------------------------------------------------------
 # version of meld which is able to run in a CMSSW environment
+#-------------------------------------------------------------
 alias mld='PATH=/opt/ogs/bin/linux-x64:/wlcg/sw/git/current/bin:/usr/local/bin:/usr/local/bin/X11:/usr/bin:/bin:/usr/bin/X11:/cern/pro/bin:/usr/kerberos/bin LD_LIBRARY_PATH=/opt/ogs/lib/linux-x64 PYTHONPATH="" meld'
 
-
-export GREP_OPTIONS='--color=auto'
-
+#-------------------------------------------------------------
 # qstat-like script with job summary for all users
+#-------------------------------------------------------------
 myqstat()
 {
 echo -e "\n   User     Jobs     r   %\n------------------------------------------------------------"; qstat -u "*" -s prs | tail -n+3 | cut -c28-40 | sort | uniq -c | awk ' { t = $1; $1 = $2; $2 = t; print; } ' > /tmp/alljobs_${USER}.txt && qstat -u "*" -s r | tail -n+3 | cut -c28-40 | sort | uniq -c | awk ' { t = $1; $1 = $2; $2 = t; print; } ' > /tmp/rjobs_${USER}.txt && awk 'NR==FNR{a[$1]=$2;k[$1];next}{b[$1]=$2;k[$1]}END{for(x in k)printf"%s %d %d\n",x,a[x],b[x]}'  /tmp/alljobs_${USER}.txt /tmp/rjobs_${USER}.txt  | sort -k2 -n -r | awk -v len=$((`tput cols`-30)) '!max{max=$2;}{r="";i=s=len*($2-$3)/max;while(i-->0)r=r"\033[1;33m#\033[0m";q="";i=s=len*$3/max;while(i-->0)q=q"\033[0;32m#\033[0m";printf "%11s %5d %5d %3d%s %s%s%s",$1,$2,$3,($3/$2*100),"%",q,r,"\n";}' | grep -E "${USER}|$"
@@ -96,7 +164,9 @@ listwarnings()
   grep -E "warning|error|\[-W.*\]"
 }
 
+#-------------------------------------------------------------
 # special files for ekp, naf, user
+#-------------------------------------------------------------
 if [[ $HOSTNAME == *ekpcms* ]]; then
     [ -f $BASHRCDIR/ekp.sh ] && source $BASHRCDIR/ekp.sh
     # check for SLC5/6:
@@ -109,4 +179,3 @@ elif [[ $HOSTNAME == *naf* ]]; then
     [ -f $BASHRCDIR/naf.sh ] && source $BASHRCDIR/naf.sh
 fi
 [ -f $BASHRCDIR/users/$USER.sh ] && source $BASHRCDIR/users/$USER.sh
-

--- a/screenrc
+++ b/screenrc
@@ -4,7 +4,7 @@
 startup_message off
 caption always "%{= kw}%-w%{= BW}%n %t%{-}%+w %-= @%H - %LD, %d. %LM - %c"
 
-defscrollback 5000
+defscrollback 10000
 
 export TERM=linux
 term linux

--- a/users/ffischer.sh
+++ b/users/ffischer.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+#-------------------------------------------------------------
+# Some settings
+#-------------------------------------------------------------
+
+alias debug="set -o nounset; set -o xtrace"
+ulimit -S -c 0      # Don't want coredumps.
+set -o notify
+set -o noclobber
+set -o ignoreeof
+
+# Enable options:
+shopt -s cdspell
+shopt -s cdable_vars
+shopt -s checkhash
+shopt -s checkwinsize
+shopt -s sourcepath
+shopt -s no_empty_cmd_completion
+shopt -s cmdhist
+shopt -s histappend histreedit histverify
+shopt -s extglob       # Necessary for programmable completion.
+
+# Disable options:
+shopt -u mailwarn
+unset MAILCHECK        # Don't warn me of incoming mail.
+
+#-------------------
+# Personal Aliases
+#-------------------
+alias rm='rm -i'
+alias cp='cp -i'
+alias mv='mv -i'
+
+# -> Prevents accidentally clobbering files.
+alias mkdir='mkdir -p'
+
+alias which='type -a'
+
+# Pretty-print of some PATH variables:
+alias path='echo -e ${PATH//:/\\n}'
+alias libpath='echo -e ${LD_LIBRARY_PATH//:/\\n}'
+
+#-------------------------------------------------------------
+# Tailoring 'less'
+#-------------------------------------------------------------
+alias more='less'
+export PAGER=less
+export LESSCHARSET='latin1'
+export LESSOPEN='|/usr/bin/lesspipe.sh %s 2>&-'
+                # Use this if lesspipe.sh exists.
+export LESS='-i -w  -z-4 -g -e -M -X -F -R -P%t?f%f \
+:stdin .?pb%pb\%:?lbLine %lb:?bbByte %bb:-...'
+# add -N for line numbers
+
+# LESS man page colors (makes Man pages more readable).
+export LESS_TERMCAP_mb=$'\E[01;31m'
+export LESS_TERMCAP_md=$'\E[01;31m'
+export LESS_TERMCAP_me=$'\E[0m'
+export LESS_TERMCAP_se=$'\E[0m'
+export LESS_TERMCAP_so=$'\E[01;44;33m'
+export LESS_TERMCAP_ue=$'\E[0m'
+export LESS_TERMCAP_us=$'\E[01;32m'
+
+#-------------------------------------------------------------
+# Spelling typos
+#-------------------------------------------------------------
+alias xs='cd'
+alias vf='cd'
+alias moer='more'
+alias moew='more'
+alias kk='ll'
+
+#-------------------------------------------------------------
+# Freiburg settings
+#-------------------------------------------------------------
+[ -f $BASHRCDIR/freiburg.sh ] && source $BASHRCDIR/freiburg.sh


### PR DESCRIPTION
Restructuring and numerous additions to the default.sh:
- `ls` -> human readable format (MB, GB)
- lots of `lx`, `ll`, ... definitions
- `..`, `...`, `....` for quick directory changes
- `igrep`
- `utime` to convert unix time
- switch `mensa` to "short" plan
- `pdgid` was broken

Any opinions on these changes?

Changes via pull request, since it would affect _everyone_.
